### PR TITLE
feat(): Add altitude estimation using SRTM earth model

### DIFF
--- a/MAVProxy/modules/mavproxy_movinghome.py
+++ b/MAVProxy/modules/mavproxy_movinghome.py
@@ -129,7 +129,6 @@ class movinghome(mp_module.MPModule):
                                 mavutil.mavlink.MAV_SEVERITY_NOTICE,
                                 message.encode("utf-8")
                                 )
-                    self.console.writeln("Home position updated")
 
                     srtm_alt = self.EleModel.GetElevation(position.latitude, position.longitude, timeout=0) # returns 0 at sea - timeout==0 means try to download once
                     if srtm_alt is None: # just in case...
@@ -155,6 +154,8 @@ class movinghome(mp_module.MPModule):
                     self.lonh = position.longitude
                     self.alth = position.altitude
                     # self.console.writeln("%s: %s %s GNSS Quality %s Sats %s " % (self.name, self.lat, self.lon, msg.gps_qual, msg.num_sats))
+
+                    self.console.writeln("Home position update sent...")
 
 
     def haversine(self, lon1, lat1, alt1, lon2, lat2, alt2):

--- a/MAVProxy/modules/mavproxy_movinghome.py
+++ b/MAVProxy/modules/mavproxy_movinghome.py
@@ -37,7 +37,7 @@ class movinghome(mp_module.MPModule):
         self.last_check = time.time()
         self.fresh = True # fresh start/first movement
         self.dist = 0
-        self.EleModel = ElevationModel(database='srtm', offline=1, debug=True)
+        self.EleModel = ElevationModel(database='srtm', offline=1, debug=False)
 
         self.add_command('movinghome', self.cmd_movinghome, "movinghome module")
 
@@ -131,7 +131,7 @@ class movinghome(mp_module.MPModule):
                                 )
                     self.console.writeln("Home position updated")
 
-                    srtm_alt = self.EleModel.GetElevation(position.latitude, position.longitude, timeout=10) # returns 0 at sea
+                    srtm_alt = self.EleModel.GetElevation(position.latitude, position.longitude, timeout=0) # returns 0 at sea - timeout==0 means try to download once
                     if srtm_alt is None: # just in case...
                         srtm_alt=0
                     self.console.writeln("SRTM-Altitude: {}m".format(srtm_alt))


### PR DESCRIPTION
We can use the built in SRTM database to get altitude for a given homeposition.

The elevation model data needs to be downloaded beforehand, as we have a offline usage.

The download will take place in the pi-gen module.