### PR TITLE
Add checking of home position ack messages

### DIFF
--- a/MAVProxy/modules/mavproxy_link.py
+++ b/MAVProxy/modules/mavproxy_link.py
@@ -747,6 +747,8 @@ class LinkModule(mp_module.MPModule):
                 if (m.target_component not in [mavutil.mavlink.MAV_COMP_ID_MAVCAN] and
                     m.command not in [mavutil.mavlink.MAV_CMD_GET_HOME_POSITION]):
                     self.mpstate.console.writeln("Got COMMAND_ACK: %s: %s" % (cmd, res))
+                if (m.command == mavutil.mavlink.MAV_CMD_DO_SET_HOME):
+                    self.mpstate.time_last_home_ack = time.time()
             except Exception:
                 self.mpstate.console.writeln("Got MAVLink msg: %s" % m)
 

--- a/MAVProxy/modules/mavproxy_movinghome.py
+++ b/MAVProxy/modules/mavproxy_movinghome.py
@@ -47,6 +47,13 @@ class movinghome(mp_module.MPModule):
         self.fresh = True #fresh start/first movement
         self.dist = 0
         self.last_decode_error_print = 0
+        # home position ack settings
+        self.home_position_ack_timeout = 3 # seconds
+        self.last_home_position_ack = None # last acknowledged home position 
+        self.time_last_home_sent = None # time of last home position sent
+        self.mpstate.time_last_home_ack = None # time of last home position ack - shared variable from mavproxy_link module
+        self.qgc_connection = None # to send messages to QGC
+        self.debug_ack = False
 
         print("\nDefault NMEA source is: %s at %s baud, change if needed before turning on." % (self.device , self.baud))
         self.add_command('movinghome', self.cmd_movinghome, "movinghome module")
@@ -93,7 +100,6 @@ class movinghome(mp_module.MPModule):
             print("Not updating home")
         print("Radius is %sm \nInterval is %ss \nDevice is %s at %s baud\n" % (self.radius, self.check_interval, self.device, self.baud ))
 
-
     def movinghome_on(self):
         #self.ser = serial.Serial('/dev/ttyUSB0',4800)
         self.ser = serial.Serial(self.device,self.baud)
@@ -107,9 +113,27 @@ class movinghome(mp_module.MPModule):
         self.updating = False
         print("Home position will not be updated.")
 
+    def check_home_position_ack(self):
+        # Check if we have received a home position ACK for last update
+        time_last_home_ack=self.mpstate.time_last_home_ack
+        if time_last_home_ack is None:
+            self.alert_mavproxy_and_qgc("Never received a Home position ACK!", mavutil.mavlink.MAV_SEVERITY_CRITICAL)
+        elif time_last_home_ack and self.time_last_home_sent:
+            time_since_last_ack =  time_last_home_ack - self.time_last_home_sent
+            if self.debug_ack:
+                self.alert_mavproxy_and_qgc("time_since_last_ack: %s s" % round(time_since_last_ack,4),mavutil.mavlink.MAV_SEVERITY_CRITICAL)
+            if time_since_last_ack > self.home_position_ack_timeout:
+                self.alert_mavproxy_and_qgc("Home position ACK timed out: %s s" % round(time_since_last_ack,4),mavutil.mavlink.MAV_SEVERITY_CRITICAL)
+                if self.last_home_position_ack:
+                    self.alert_mavproxy_and_qgc("Last successful sent home position",mavutil.mavlink.MAV_SEVERITY_CRITICAL)
+                    self.alert_mavproxy_and_qgc("lat %s lon %s" % (round(self.lath,4), round(self.lonh,4)),mavutil.mavlink.MAV_SEVERITY_CRITICAL) # ~11m accuracy
+            else:
+                self.last_home_position_ack = {"lat": self.lath, "lon": self.lonh, "alt": self.alth}
+
     def idle_task(self):
         #Called frequently by mavproxy
         if self.updating == True:
+            # process new NMEA data
             data = self.ser.readline()
             try:
                 data = data.decode("ascii")
@@ -138,6 +162,8 @@ class movinghome(mp_module.MPModule):
 
                 now = time.time()
                 if now-self.last_check > self.check_interval:
+                    self.check_home_position_ack()
+
                     self.last_check = now
                     #check if we moved enough
                     self.dist = self.haversine(self.lon, self.lat, self.alt, self.lonh, self.lath, self.alth)
@@ -166,9 +192,13 @@ class movinghome(mp_module.MPModule):
                         int(self.lat*1e7), # param5
                         int(self.lon*1e7), # param6
                         0) # param7
+                        
+                        self.time_last_home_sent = time.time()
 
                         self.lath = self.lat
                         self.lonh = self.lon
+                        self.alth = 0
+
                         #print data
                         self.console.writeln("%s: %s %s GNSS Quality %s Sats %s "% (self.name,self.lat,self.lon,msg.gps_qual,msg.num_sats))
 
@@ -183,6 +213,24 @@ class movinghome(mp_module.MPModule):
         d = c*r_earth
         return math.sqrt(d**2+(alt1 - alt2)**2)
 
+    def alert_mavproxy_and_qgc(self, msg, severity=mavutil.mavlink.MAV_SEVERITY_NOTICE):
+        # Send alert to mavproxy console
+        self.console.writeln(
+            msg,
+        )
+        # Send alert to QGC
+        if self.qgc_connection is None:    
+            self.connect_to_gqc()
+        if self.qgc_connection is not None:
+            self.qgc_connection.mav.statustext_send(
+                severity,
+                msg.encode("utf-8")
+            )
+            
+    def connect_to_gqc(self):
+        target_system=self.mpstate.settings.target_system
+        if target_system and target_system != 0:
+            self.qgc_connection = mavutil.mavlink_connection('udpout:0.0.0.0:14550', source_system=target_system, source_component=220)
 
 def init(mpstate):
     return movinghome(mpstate)


### PR DESCRIPTION
Do checks by capturing specific DO_SET_HOME message acks timestamps in mavproxy_link module. 

Then access this variable in movinghome module and compare with current timestamp. 

Raise alert to user via QGC if ack timeout of 3 seconds is met. 

In this case also show last set succesful set home position to the user.



